### PR TITLE
Fixes to support terraform-docs 0.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary
+      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
     steps:
       - checkout
       - restore_cache:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.22.0
+    rev: v1.24.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.22.2
+    rev: v1.23.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -37,11 +37,22 @@ module "r53_query_logging" {
 * Terraform 0.11. Pin module version to ~> 1.0. Submit pull requests to `terraform011` branch.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.us-east-1 | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| logs\_cloudwatch\_retention | Specifies the number of days you want to retain log events in the log group. | string | `"90"` | no |
-| zone\_id | Route53 zone ID. | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| logs\_cloudwatch\_retention | Specifies the number of days you want to retain log events in the log group. | `string` | `90` | no |
+| zone\_id | Route53 zone ID. | `string` | n/a | yes |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
terraform-docs 0.8 will dump some inline HTML in the readme for object variable, so I've removed the rule from the markdownlint config.