### PR TITLE
Update aws-r53 query logs to reuse a resource policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.1
+    rev: v1.27.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ module "r53_query_logging" {
 * Terraform 0.11. Pin module version to ~> 1.0. Submit pull requests to `terraform011` branch.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -47,7 +53,8 @@ module "r53_query_logging" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
+| enable\_resource\_policy | n/a | `bool` | `true` | no |
 | logs\_cloudwatch\_retention | Specifies the number of days you want to retain log events in the log group. | `string` | `90` | no |
 | zone\_id | Route53 zone ID. | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "r53_query_logging" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| enable\_resource\_policy | n/a | `bool` | `true` | no |
+| create\_resource\_policy | Specifies whether the module should create the resource policy. | `bool` | `true` | no |
 | logs\_cloudwatch\_retention | Specifies the number of days you want to retain log events in the log group. | `string` | `90` | no |
 | zone\_id | Route53 zone ID. | `string` | n/a | yes |
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,7 +1,13 @@
 resource "aws_route53_zone" "my_zone" {
   name = var.zone_id
-
 }
+
+resource "aws_cloudwatch_log_resource_policy" "main" {
+  provider        = aws.us-east-1
+  policy_document = data.aws_iam_policy_document.main.json
+  policy_name     = "route53-query-logging-policy-${var.zone_id}"
+}
+
 module "r53_query_logging" {
   source = "../.."
 
@@ -11,4 +17,5 @@ module "r53_query_logging" {
 
   logs_cloudwatch_retention = 30
   zone_id                   = aws_route53_zone.my_zone.zone_id
+  enable_resource_policy    = var.enable_resource_policy
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,7 +2,7 @@ resource "aws_route53_zone" "my_zone" {
   name = var.zone_id
 }
 
-data "aws_iam_policy_document" "main" {
+data "aws_iam_policy_document" "test" {
   count = var.enable_resource_policy ? 0 : 1
   statement {
     actions = [
@@ -19,11 +19,11 @@ data "aws_iam_policy_document" "main" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "main" {
+resource "aws_cloudwatch_log_resource_policy" "test" {
   count           = var.enable_resource_policy ? 0 : 1
   provider        = aws.us-east-1
-  policy_document = data.aws_iam_policy_document.main[0].json
-  policy_name     = "route53-query-logging-policy-${var.zone_id}"
+  policy_document = data.aws_iam_policy_document.test[0].json
+  policy_name     = "route53-query-logging-policy-${var.zone_id}-test"
 }
 
 module "r53_query_logging" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,9 +2,27 @@ resource "aws_route53_zone" "my_zone" {
   name = var.zone_id
 }
 
+data "aws_iam_policy_document" "main" {
+  count = var.enable_resource_policy ? 0 : 1
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+
+    principals {
+      identifiers = ["route53.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
 resource "aws_cloudwatch_log_resource_policy" "main" {
+  count           = var.enable_resource_policy ? 0 : 1
   provider        = aws.us-east-1
-  policy_document = data.aws_iam_policy_document.main.json
+  policy_document = data.aws_iam_policy_document.main[0].json
   policy_name     = "route53-query-logging-policy-${var.zone_id}"
 }
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -3,7 +3,7 @@ resource "aws_route53_zone" "my_zone" {
 }
 
 data "aws_iam_policy_document" "test" {
-  count = var.enable_resource_policy ? 0 : 1
+  count = var.create_resource_policy ? 0 : 1
   statement {
     actions = [
       "logs:CreateLogStream",
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "test" {
-  count           = var.enable_resource_policy ? 0 : 1
+  count           = var.create_resource_policy ? 0 : 1
   provider        = aws.us-east-1
   policy_document = data.aws_iam_policy_document.test[0].json
   policy_name     = "route53-query-logging-policy-${var.zone_id}-test"
@@ -35,5 +35,5 @@ module "r53_query_logging" {
 
   logs_cloudwatch_retention = 30
   zone_id                   = aws_route53_zone.my_zone.zone_id
-  enable_resource_policy    = var.enable_resource_policy
+  create_resource_policy    = var.create_resource_policy
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -7,7 +7,7 @@ variable "logs_cloudwatch_retention" {
   default = "90"
 }
 
-variable "enable_resource_policy" {
+variable "create_resource_policy" {
   type    = bool
   default = true
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -6,3 +6,8 @@ variable "logs_cloudwatch_retention" {
   type    = string
   default = "90"
 }
+
+variable "enable_resource_policy" {
+  type    = bool
+  default = true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/trussworks/terraform-aws-route53-query-logs
 go 1.13
 
 require (
+	github.com/aws/aws-sdk-go v1.27.1
 	github.com/gruntwork-io/terratest v0.27.3
 	github.com/stretchr/testify v1.5.1
 )

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_log_group" "main" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "main" {
-  count = var.enable_resource_policy ? 1 : 0
+  count           = var.enable_resource_policy ? 1 : 0
   provider        = aws.us-east-1
   policy_document = data.aws_iam_policy_document.main.json
   policy_name     = "route53-query-logging-policy-${var.zone_id}"
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "main" {
 resource "aws_route53_query_log" "main" {
   // how do I change the depends_on to acknowledge the variable in an "if"-type clause?
   // can I use an empty list here?
-  depends_on               = [aws_cloudwatch_log_resource_policy.main]
+  depends_on               = []
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.main.arn
   zone_id                  = var.zone_id
 }

--- a/main.tf
+++ b/main.tf
@@ -10,14 +10,14 @@ resource "aws_cloudwatch_log_group" "main" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "main" {
-  count           = var.enable_resource_policy ? 1 : 0
+  count           = var.create_resource_policy ? 1 : 0
   provider        = aws.us-east-1
   policy_document = data.aws_iam_policy_document.main[0].json
   policy_name     = "route53-query-logging-policy-${var.zone_id}"
 }
 
 data "aws_iam_policy_document" "main" {
-  count = var.enable_resource_policy ? 1 : 0
+  count = var.create_resource_policy ? 1 : 0
   statement {
     actions = [
       "logs:CreateLogStream",

--- a/main.tf
+++ b/main.tf
@@ -12,11 +12,12 @@ resource "aws_cloudwatch_log_group" "main" {
 resource "aws_cloudwatch_log_resource_policy" "main" {
   count           = var.enable_resource_policy ? 1 : 0
   provider        = aws.us-east-1
-  policy_document = data.aws_iam_policy_document.main.json
+  policy_document = data.aws_iam_policy_document.main[0].json
   policy_name     = "route53-query-logging-policy-${var.zone_id}"
 }
 
 data "aws_iam_policy_document" "main" {
+  count = var.enable_resource_policy ? 1 : 0
   statement {
     actions = [
       "logs:CreateLogStream",
@@ -33,9 +34,7 @@ data "aws_iam_policy_document" "main" {
 }
 
 resource "aws_route53_query_log" "main" {
-  // how do I change the depends_on to acknowledge the variable in an "if"-type clause?
-  // can I use an empty list here?
-  depends_on               = []
+  #depends_on               = var.enable_resource_policy ? [aws_cloudwatch_log_resource_policy[0].main] : []
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.main.arn
   zone_id                  = var.zone_id
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ resource "aws_cloudwatch_log_group" "main" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "main" {
+  count = var.enable_resource_policy ? 1 : 0
   provider        = aws.us-east-1
   policy_document = data.aws_iam_policy_document.main.json
   policy_name     = "route53-query-logging-policy-${var.zone_id}"
@@ -32,6 +33,8 @@ data "aws_iam_policy_document" "main" {
 }
 
 resource "aws_route53_query_log" "main" {
+  // how do I change the depends_on to acknowledge the variable in an "if"-type clause?
+  // can I use an empty list here?
   depends_on               = [aws_cloudwatch_log_resource_policy.main]
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.main.arn
   zone_id                  = var.zone_id

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,6 @@ data "aws_iam_policy_document" "main" {
 }
 
 resource "aws_route53_query_log" "main" {
-  #depends_on               = var.enable_resource_policy ? [aws_cloudwatch_log_resource_policy[0].main] : []
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.main.arn
   zone_id                  = var.zone_id
 }

--- a/test/terraform-aws-route53-query-logs_test.go
+++ b/test/terraform-aws-route53-query-logs_test.go
@@ -80,7 +80,7 @@ func TestTerraformRoute53QueryLogWithDisabledResourcePolicy(t *testing.T) {
 		Vars: map[string]interface{}{
 			"logs_cloudwatch_retention": "30",
 			"zone_id":                   fmt.Sprintf("%s.com", testName),
-			"enable_resource_policy":    false,
+			"create_resource_policy":    false,
 		},
 
 		// Environment variables to set when running Terraform

--- a/test/terraform-aws-route53-query-logs_test.go
+++ b/test/terraform-aws-route53-query-logs_test.go
@@ -32,6 +32,46 @@ func TestTerraformRoute53QueryLog(t *testing.T) {
 		Vars: map[string]interface{}{
 			"logs_cloudwatch_retention": "30",
 			"zone_id":                   fmt.Sprintf("%s.com", testName),
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// This will ensure the log stream is not empty
+	logs := aws.GetCloudWatchLogEntries(t, awsRegion, "route53-test-log-stream", logGroupName)
+	require.NotNil(t, logs)
+	fmt.Println(logs)
+}
+
+func TestTerraformRoute53QueryLogWithDisabledResourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+
+	// Give this Route53 Zone a unique ID for a name tag so we can distinguish it from any other zones provisioned
+	// in your AWS account
+	testName := fmt.Sprintf("terratest-aws-route53-query-logs-%s", strings.ToLower(random.UniqueId()))
+	logGroupName := fmt.Sprintf("/aws/route53/%s.com.", testName)
+	// This _must_ be "us-east-1" unlike our other tests as Route53 query logs are _only_ available in us-east-1.
+	awsRegion := "us-east-1"
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"logs_cloudwatch_retention": "30",
+			"zone_id":                   fmt.Sprintf("%s.com", testName),
 			"enable_resource_policy":    false,
 		},
 
@@ -48,5 +88,7 @@ func TestTerraformRoute53QueryLog(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	// This will ensure the log stream is not empty
-	require.NotNil(t, aws.GetCloudWatchLogEntries(t, awsRegion, "route53-test-log-stream", logGroupName))
+	logs := aws.GetCloudWatchLogEntries(t, awsRegion, "route53-test-log-stream", logGroupName)
+	require.NotNil(t, logs)
+	fmt.Println(logs)
 }

--- a/test/terraform-aws-route53-query-logs_test.go
+++ b/test/terraform-aws-route53-query-logs_test.go
@@ -32,6 +32,7 @@ func TestTerraformRoute53QueryLog(t *testing.T) {
 		Vars: map[string]interface{}{
 			"logs_cloudwatch_retention": "30",
 			"zone_id":                   fmt.Sprintf("%s.com", testName),
+			"enable_resource_policy":    false,
 		},
 
 		// Environment variables to set when running Terraform

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,7 @@ variable "zone_id" {
   description = "Route53 zone ID."
   type        = string
 }
+
+variable "enable_resource_policy" {
+  type = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,5 +10,6 @@ variable "zone_id" {
 }
 
 variable "enable_resource_policy" {
-  type = bool
+  type    = bool
+  default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,8 @@ variable "zone_id" {
   type        = string
 }
 
-variable "enable_resource_policy" {
-  type    = bool
-  default = true
+variable "create_resource_policy" {
+  type        = bool
+  description = "Specifies whether the module should create the resource policy."
+  default     = true
 }


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/172927707)

Bugfix jamming up a series of tickets to get `truss.design` where it needs to be

Changes proposed in this pull request:

Creates the following:
- var to no longer make the thing need the thing