### PR TITLE
Newer AWS provider (3.x) doesn't output the ending . on zone name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_route53_zone" "main" {
 resource "aws_cloudwatch_log_group" "main" {
   provider = aws.us-east-1
 
-  name              = "/aws/route53/${data.aws_route53_zone.main.name}"
+  name              = "/aws/route53/${data.aws_route53_zone.main.name}."
   retention_in_days = var.logs_cloudwatch_retention
 }
 
@@ -37,4 +37,3 @@ resource "aws_route53_query_log" "main" {
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.main.arn
   zone_id                  = var.zone_id
 }
-


### PR DESCRIPTION
So we append a `.` so we don't have to recreate existing bits. 