### PR TITLE
Update alternative provider syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:caa7ee5c649b541f3fde6473d32b045bcfdb93ef
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.28.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.50.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.41.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -45,26 +45,39 @@ module "r53_query_logging" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
-| aws.us-east-1 | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_route53_query_log.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log) | resource |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_resource\_policy | Specifies whether the module should create the resource policy. | `bool` | `true` | no |
-| logs\_cloudwatch\_retention | Specifies the number of days you want to retain log events in the log group. | `string` | `90` | no |
-| zone\_id | Route53 zone ID. | `string` | n/a | yes |
+| <a name="input_create_resource_policy"></a> [create\_resource\_policy](#input\_create\_resource\_policy) | Specifies whether the module should create the resource policy. | `bool` | `true` | no |
+| <a name="input_logs_cloudwatch_retention"></a> [logs\_cloudwatch\_retention](#input\_logs\_cloudwatch\_retention) | Specifies the number of days you want to retain log events in the log group. | `string` | `90` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 zone ID. | `string` | n/a | yes |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,0 @@
-# Terraform 0.12 requires providers that aren't implicitly passed into the
-# module. Adding "region" will prevent us from being able to remove this
-# module.
-# See https://github.com/hashicorp/terraform/issues/22907 for details.
-provider "aws" {
-  alias = "us-east-1"
-}
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
   required_version = ">= 0.13"
-
   required_providers {
-    aws = ">= 3.0"
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 3.0"
+      configuration_aliases = [aws.us-east-1]
+    }
   }
 }


### PR DESCRIPTION
Terraform 0.15 changed the way to call alternate providers and right now this module generates a warning because it's still using the old syntax. This PR updates things according to https://www.terraform.io/upgrade-guides/0-15.html#alternative-provider-configurations-within-modules. 