### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "r53_query_logging" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ module "r53_query_logging" {
 }
 ```
 
-## Terraform Versions
-
-- Terraform 0.13 and newer. Pin module version to ~> 3.0. Submit pull requests to `master` branch.
-- Terraform 0.12. Pin module version to ~> 2.0. Submit pull requests to `terraform012` branch.
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     aws = {
       source                = "hashicorp/aws"


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
